### PR TITLE
feat(message): resolve #14 reply to message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,14 @@ export const App = () => {
                   </AuthenticatedRoute>
                 }
               />
+              <Route
+                path="/send/:from/:to"
+                element={
+                  <AuthenticatedRoute>
+                    <SendPage />
+                  </AuthenticatedRoute>
+                }
+              />
               <Route path="/ui" element={<UiPage />} />
               <Route path="*" element={<NotFoundPage />} />
             </Routes>

--- a/src/component/MessagePage/MessagePage.jsx
+++ b/src/component/MessagePage/MessagePage.jsx
@@ -1,11 +1,35 @@
 import { useEffect, useState } from "react"
 import { Layout } from "../Layout/Layout"
 import { getTwilioMessage } from "../../js/getTwilioMessages"
-import { useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import { MessageInfo } from "../MessageInfo/MessageInfo"
 import { LoadingOutlined } from "@ant-design/icons"
 import { ErrorLabel } from "../ErrorLabel/ErrorLabel"
-import { Link } from "react-router-dom"
+
+/**
+ * @typedef {import("../../js/types").Message} Message
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {Message} props.message
+ */
+const MessagePanel = ({ message }) => {
+  const navigate = useNavigate()
+  const isReceived = message.direction === "received"
+  const isSent = message.direction === "sent"
+  return (
+    <>
+      <MessageInfo message={message} />
+      <div className="mt-4 text-right space-x-4">
+        <button onClick={() => navigate(`/conversation/${message.from}/${message.to}`)}>See Conversation</button>
+        {isReceived && <button onClick={() => navigate(`/send/${message.to}/${message.from}`)}>Reply</button>}
+        {isSent && <button onClick={() => navigate(`/send/${message.from}/${message.to}`)}>New Message</button>}
+      </div>
+    </>
+  )
+}
 
 export const MessagePage = () => {
   const { messageSid } = useParams()
@@ -24,18 +48,13 @@ export const MessagePage = () => {
     <Layout>
       <h3>Message</h3>
       <ErrorLabel error={error} />
-      <p className="my-4">
-        More details for your message. You may also view all &nbsp;
-        <Link to={`/conversation/${message.from}/${message.to}`}>
-          messages between {message.from} and {message.to}
-        </Link>
-      </p>
+      <p className="my-4">More details for your message.</p>
       {loading && (
         <p className="mt-10 text-purple-900 text-5xl text-center">
           <LoadingOutlined />
         </p>
       )}
-      {!loading && <MessageInfo message={message} />}
+      {!loading && <MessagePanel message={message} />}
     </Layout>
   )
 }

--- a/src/component/SendPage/SendPage.jsx
+++ b/src/component/SendPage/SendPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
 import { useAuthentication } from "../../context/AuthenticationProvider"
 import { getTwilioPhoneNumbers } from "../../js/getTwilioPhoneNumbers"
 import { sendTwilioMessage } from "../../js/sendTwilioMessage"
@@ -10,9 +10,10 @@ import { ErrorLabel } from "../ErrorLabel/ErrorLabel"
 import { Loading3QuartersOutlined } from "@ant-design/icons"
 
 export const SendPage = () => {
+  const { from: fromParam, to: toParam } = useParams()
   const [phoneNumbers, setPhoneNumbers] = useState([])
-  const [from, setFrom] = useState("")
-  const [to, setTo] = useState("")
+  const [from, setFrom] = useState(fromParam ?? "")
+  const [to, setTo] = useState(toParam ?? "")
   const [message, setMessage] = useState("")
   const [loadingPhoneNumbers, setLoadingPhoneNumbers] = useState(true)
   const [sendingMessage, setSendingMessage] = useState(false)
@@ -59,6 +60,7 @@ export const SendPage = () => {
       <div className="flex items-center">
         <label className="w-14">From:</label>
         <PhoneCombobox
+          initial={from}
           options={phoneNumbers}
           onSelect={setFrom}
           loading={loadingPhoneNumbers}

--- a/src/component/SentPage/SentPage.jsx
+++ b/src/component/SentPage/SentPage.jsx
@@ -6,7 +6,28 @@ import { MessageInfo } from "../MessageInfo/MessageInfo"
 import { LoadingOutlined } from "@ant-design/icons"
 import { ErrorLabel } from "../ErrorLabel/ErrorLabel"
 import { CheckCircleFilled } from "@ant-design/icons"
-import { Link } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
+
+/**
+ * @typedef {import("../../js/types").Message} Message
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {Message} props.message
+ */
+const MessagePanel = ({ message }) => {
+  const navigate = useNavigate()
+  return (
+    <>
+      <MessageInfo message={message} />
+      <div className="mt-4 text-right space-x-4">
+        <button onClick={() => navigate(`/conversation/${message.from}/${message.to}`)}>See Conversation</button>
+      </div>
+    </>
+  )
+}
 
 export const SentPage = () => {
   const { messageSid } = useParams()
@@ -27,18 +48,13 @@ export const SentPage = () => {
         <CheckCircleFilled className="text-green-600" /> Message Sent
       </h3>
       <ErrorLabel error={error} />
-      <p className="my-4">
-        Your message has been sent. You may also view all &nbsp;
-        <Link to={`/conversation/${message.from}/${message.to}`}>
-          messages between {message.from} and {message.to}
-        </Link>
-      </p>
+      <p className="my-4">Your message has been sent.</p>
       {loading && (
         <p className="mt-10 text-purple-900 text-5xl text-center">
           <LoadingOutlined />
         </p>
       )}
-      {!loading && <MessageInfo message={message} />}
+      {!loading && <MessagePanel message={message} />}
     </Layout>
   )
 }


### PR DESCRIPTION
User Story
As a user, I want the ability to quickly reply to a message without manually typing the from and to phone numbers, so that I can respond to my messages more efficiently.

Proposed Solution
- The user navigates to the Inbox page and selects one of their messages.
- The app navigates to the Message page, displaying more information about the selected message.
- A Reply button is added to this page. When clicked: The app navigates to the Send page. The from and to phone numbers are pre-filled, taken directly from the original message.